### PR TITLE
fix: unit window ui overlap

### DIFF
--- a/src/components/Unit.tsx
+++ b/src/components/Unit.tsx
@@ -2,6 +2,7 @@ interface UnitProps {
   x: number;
   y: number;
   type: string;
+  unitId: number;
   npc?: boolean | undefined;
   health?: number;
   level?: number;
@@ -9,7 +10,7 @@ interface UnitProps {
   onClick: (x: number, y: number) => void;
 }
 
-const Unit: React.FC<UnitProps> = ({ x, y, type, npc, health, level, isSelected, onClick }) => {
+const Unit: React.FC<UnitProps> = ({ x, y, type, npc, health, level, isSelected, unitId, onClick }) => {
   const handleClick = () => {
     onClick(x, y);
   };
@@ -17,7 +18,7 @@ const Unit: React.FC<UnitProps> = ({ x, y, type, npc, health, level, isSelected,
   const img = npc ? `npc-${type}` : type;
 
   return (
-    <div className={`unit unit-${type} ${isSelected ? "selected" : ""} ${npc ? "npc" : ""}`} onClick={handleClick}>
+    <div id={`unit-${unitId}`} className={`unit unit-${type} ${isSelected ? "selected" : ""} ${npc ? "npc" : ""}`} onClick={handleClick}>
       <div className="unit-header">
         {level ? (
           <div className="level">

--- a/src/components/UnitInfoWindow.tsx
+++ b/src/components/UnitInfoWindow.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { toast } from "react-toastify";
 import Button from "@mui/material/Button";
 import Tippy from "@tippyjs/react";
@@ -9,6 +9,8 @@ import { canUpgradeUnit } from "../utils";
 import { useWorkspace } from "../context/AnchorContext";
 import { useGameState } from "../context/GameStateContext";
 import { useSound } from "../context/SoundContext";
+
+type WindowAlignment = 'left' | 'right' | null;
 
 interface UnitInfoProps {
   unit: {
@@ -26,11 +28,26 @@ interface UnitInfoProps {
 }
 
 const UnitInfoWindow: React.FC<UnitInfoProps> = ({ unit }) => {
+  const [alignment, setAlignment] = useState<WindowAlignment>(null)
   const { program, provider } = useWorkspace();
   const { cities, fetchPlayerState } = useGameState();
   const { playSound } = useSound();
   const { type, movementRange, attack, experience, level } = unit;
   const displayType = type.charAt(0).toUpperCase() + type.slice(1);
+
+  useEffect(() => {
+    const element = document.getElementById(`unit-${unit?.unitId}`);
+    if(element) {
+      const rect = element.getBoundingClientRect();
+      const distanceFromRight = window.innerWidth - rect.right;
+
+      if(distanceFromRight < 300) {
+        setAlignment('left');
+      } else {
+        setAlignment('right');
+      }
+    }
+  }, []);
 
   const getUnusedCityName = () => {
     const usedNames = cities.map((city) => city.name);
@@ -119,7 +136,7 @@ const UnitInfoWindow: React.FC<UnitInfoProps> = ({ unit }) => {
   };
 
   return (
-    <div className="unit-info-window">
+    <div className={`unit-info-window align-${alignment}`}>
       <img src={`/${type}.png`} className="avatar" alt={type} />
       <div className="desktop-only">
         <strong>{displayType}</strong>

--- a/src/components/UnitInfoWindow.tsx
+++ b/src/components/UnitInfoWindow.tsx
@@ -41,6 +41,7 @@ const UnitInfoWindow: React.FC<UnitInfoProps> = ({ unit }) => {
       const rect = element.getBoundingClientRect();
       const distanceFromRight = window.innerWidth - rect.right;
 
+      // the unit window is 240px wide defined in the css
       if(distanceFromRight < 300) {
         setAlignment('left');
       } else {

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -214,7 +214,7 @@ div.unit {
     font-size: 1rem;
     color: white;
   }
-  
+
 }
 
 div.unit img {
@@ -276,10 +276,17 @@ img.upgraded-tile {
   top: -8px;
 }
 
+.align-left {
+  left: 20px;
+}
+
+.align-right {
+  right: 20px;
+}
+
 .unit-info-window {
   position: absolute;
   bottom: 10px;
-  right: 20px;
   padding: 30px 10px;
   width: 240px;
   z-index: 100;
@@ -736,29 +743,29 @@ img.yield-icon {
     right: 0;
     box-sizing: border-box;
     margin: 0;
-    padding: 10px; 
-    border-radius: 0; 
-    flex-direction: row; 
+    padding: 10px;
+    border-radius: 0;
+    flex-direction: row;
     align-items: center;
     justify-content: space-between;
   }
 
   .unit-info-window img.avatar {
-    max-width: 32px; 
+    max-width: 32px;
   }
 
   .unit-stats,
   .unit-info-window strong {
-    font-size: 0.8rem; 
+    font-size: 0.8rem;
   }
 
   .unit-info-window img.unit-icon {
-    width: 16px; 
+    width: 16px;
   }
 
   .unit-info-window button.unit-action-button {
     width: auto;
-    margin: 0 10px; 
+    margin: 0 10px;
     font-size: 0.8rem;
   }
 }


### PR DESCRIPTION
Solvin issue [UI Overlap Issue #5](https://github.com/proxycapital/solana-civ-frontend/issues/5)

# Problem

When a unit is positioned too close to the bottom right of the screen, the information window overlaps the unit and the surrounding game tiles.

# Solution

The component that displays unit information receives the unit ID and retrieves the HTML element to determine the element's position on the screen. It then checks if the distance is too close, based on the unit window size, to render in the right or left corner.

![image](https://github.com/proxycapital/solana-civ-frontend/assets/15316761/1ebd3012-5e48-4fb4-9c46-71498e47a946)
![image](https://github.com/proxycapital/solana-civ-frontend/assets/15316761/79c48cae-7ecd-469c-8088-0d88b5b2bb1d)
