### PR TITLE
fix: unit info ui flicking

### DIFF
--- a/src/components/UnitInfoWindow.tsx
+++ b/src/components/UnitInfoWindow.tsx
@@ -122,6 +122,8 @@ const UnitInfoWindow: React.FC<UnitInfoProps> = ({ unit }) => {
     await fetchPlayerState();
   };
 
+  if(!alignment) return <></>;
+
   return (
     <div className={`unit-info-window align-${alignment}`}>
       <img src={`/${type}.png`} className="avatar" alt={type} />


### PR DESCRIPTION
# Problem

The default setting for displaying the unit information window is on the left. However, if the logic determines that the window should be rendered on the right, it initially appears on the left and, after a few seconds, is correctly rendered on the right.

https://github.com/proxycapital/solana-civ-frontend/assets/15316761/3ebbd75e-637e-4d5c-99c3-72d69abc62ee
> Due to the video's FPS, the problem is not always captured.

# Solution

Only display the unit information window after the window's position has been calculated.
