### PR TITLE
Feature: Tile Menu

### DIFF
--- a/src/components/GameMap.tsx
+++ b/src/components/GameMap.tsx
@@ -433,6 +433,11 @@ const GameMap: React.FC<GameMapProps> = ({ debug, logMessage }) => {
       setSelectedTile(null);
     }
 
+    if(unitsInTile.length === 1 && tileUnits.length === 1) {
+      unitAction(col, row, unitsInTile[0].type || "unknown");
+      return;
+    }
+
     // if there is more than one unit in the tile and the selected unit is not in the tile, show menu
     if(tileUnits.length > 1 && (!selectedUnit || !unitsInTile.find(unit => selectedUnit.unitId === unit.unitId && !unit.isSelected)) ) {
       if(selectedTile?.x  === col && selectedTile?.y === row) {

--- a/src/components/GameMap.tsx
+++ b/src/components/GameMap.tsx
@@ -8,7 +8,7 @@ import Unit from "./Unit";
 import UnitInfoWindow from "./UnitInfoWindow";
 import CityModal from "./CityModal";
 import UpgradedTileModal, { UpgradedTileType } from "./UpgradedTileModal";
-import {City, useGameState} from "../context/GameStateContext";
+import { City, useGameState } from "../context/GameStateContext";
 import { useWorkspace } from "../context/AnchorContext";
 import { useSound } from "../context/SoundContext";
 import { getMap } from "../utils/solanaUtils";
@@ -428,17 +428,23 @@ const GameMap: React.FC<GameMapProps> = ({ debug, logMessage }) => {
 
     const tileUnits: Array<Unit | City | any> = [...unitsInTile, ...upgradedUnitsInTile, ...citiesInTile];
 
-    // if there is more than one unit in the tile, show menu
-    if(tileUnits.length > 1 && (!selectedUnit || !unitsInTile.find(unit => selectedUnit.unitId === unit.unitId)) ) {
+    if(tileUnits.length === 0) {
+      setUnitsTile([]);
+      setSelectedTile(null);
+    }
+
+    // if there is more than one unit in the tile and the selected unit is not in the tile, show menu
+    if(tileUnits.length > 1 && (!selectedUnit || !unitsInTile.find(unit => selectedUnit.unitId === unit.unitId && !unit.isSelected)) ) {
       if(selectedTile?.x  === col && selectedTile?.y === row) {
         setSelectedTile(null)
         return;
-      } else {
-        setUnits(prevState => {
-          return prevState.map((unit) => ({...unit, isSelected: false}))
-        })
-        setSelectedTile({x: col, y: row})
       }
+
+      setUnits(prevState => {
+        return prevState.map((unit) => ({...unit, isSelected: false}))
+      })
+
+      setSelectedTile({x: col, y: row})
 
       setUnitsTile(tileUnits);
       return;
@@ -601,7 +607,7 @@ const GameMap: React.FC<GameMapProps> = ({ debug, logMessage }) => {
                     <img src={`/icons/${resourceAvailable}.png`} alt="" />
                   </div>
                 )}
-              {currentTile.discovered && currentUnits.map((currentUnit) => <Unit {...currentUnit} onClick={() => ""} />)}
+              {currentTile.discovered && currentUnits.map((currentUnit) => <Unit key={currentUnit.unitId} {...currentUnit} onClick={() => ""} />)}
             </div>
           );
         })}

--- a/src/components/TileMenu.tsx
+++ b/src/components/TileMenu.tsx
@@ -1,0 +1,44 @@
+import React, { CSSProperties } from 'react';
+import {City} from "../context/GameStateContext";
+
+interface CustomStyle extends CSSProperties {
+  '--index'?: number;
+  '--count'?: number;
+}
+
+interface Unit {
+  unitId: number;
+  npc?: boolean;
+  health: number;
+  x: number;
+  y: number;
+  type: string;
+  isSelected: boolean;
+  movementRange: number;
+}
+
+interface CircleMenuProps {
+  units: Array<Unit | City | any>,
+  onClick: (unitTile: Unit | City | any) => void
+}
+
+const TileMenu = ({ units, onClick }: CircleMenuProps) => {
+  return (
+    <div className="circle-menu">
+      {Array.from({ length: units.length }).map((_, index) => (
+        <div key={index} className="circle-menu-wrapper" style={{'--index': index + 1, '--count': units.length} as CustomStyle} onClick={() => {
+          onClick(units[index])
+        }}>
+          <div className="circle-menu-content">
+            {units[index].type || (units[index].cityId !== undefined && 'City') ||  Object.keys(units[index].tileType || {})[0]}
+          </div>
+        </div>
+      ))}
+
+    </div>
+  );
+}
+
+
+export default TileMenu;
+

--- a/src/context/GameStateContext.tsx
+++ b/src/context/GameStateContext.tsx
@@ -21,7 +21,7 @@ type Resources = {
   [key: string]: number | 0;
 };
 
-type City = {
+export type City = {
   cityId: number;
   x: number;
   y: number;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -592,7 +592,7 @@ img.terrain.undiscovered {
     right: 0.5rem;
     position: fixed;
     z-index: 2;
-    
+
     &:hover {
       cursor: pointer;
     }
@@ -816,4 +816,37 @@ img.yield-icon {
 
 .bold-text {
   font-weight: bold;
+}
+
+.circle-menu {
+  position: absolute;
+  z-index: 2;
+  width: 200px;
+  height: 200px;
+  left: -50px;
+  top: -50px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.circle-menu .circle-menu-wrapper {
+  position: absolute;
+  list-style: none;
+  left: 0;
+  transform-origin: 100px;
+  transform: rotate(calc(360deg / var(--count) * var(--index)));
+  transition: 0.5s;
+  background: #31c315;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+  box-shadow: 0 3px 4px rgba(0, 0, 0, 0.15);
+}
+
+.circle-menu .circle-menu-wrapper .circle-menu-content {
+  transform: rotate(calc(360deg / calc(var(--count) * -1) * var(--index)));
 }


### PR DESCRIPTION
 This pull request was created by https://app.gib.work/i/G7pBTV3_/add-a-context-menu-upon-clicking-on-a-city in an attempt to solve a bounty. Payment for the bounty is immediately sent to the contributor after merge.

# Tile Menu

Opens a menu when tile has more than one unit, city or upgraded unit.

[screen capture.webm](https://github.com/proxycapital/solana-civ-frontend/assets/15316761/6618238d-1f34-437d-8806-55e700ee82ad)

> Disclaimer: I am not an expert on React/frontend development, pretty sure that there are some performance improvements.

Close issue [Add a context menu upon clicking on a city #31](https://github.com/proxycapital/solana-civ-frontend/issues/31)