### PR TITLE
fix: production onboarding type npc village

### DIFF
--- a/src/components/EndTurnButton.tsx
+++ b/src/components/EndTurnButton.tsx
@@ -26,7 +26,7 @@ const darkTheme = createTheme({
 });
 
 interface EndTurnButtonProps {
-  setShowOnboardingType: (onboardingType: "production" | "research" | null) => void;
+  setShowOnboardingType: (onboardingType: { type: "production" | "research", col?: number, row?: number } | null) => void;
   openNewResearchModal: () => void;
 }
 
@@ -129,10 +129,11 @@ const EndTurnButton: React.FC<EndTurnButtonProps> = ({ setShowOnboardingType, op
   };
 
   const endTurn = async () => {
+
     for (let city of cities) {
       if (city.productionQueue.length === 0) {
         toast.warning(`${city.name}: production queue is empty`);
-        setShowOnboardingType("production");
+        setShowOnboardingType({ type: "production", col: city.x, row: city.y });
       }
     }
 
@@ -145,7 +146,7 @@ const EndTurnButton: React.FC<EndTurnButtonProps> = ({ setShowOnboardingType, op
         config.science["Military Tree"].length;
       if (!technologies.currentResearch && technologies.researchedTechnologies.length < totalTechnologies) {
         toast.warning("You need to select a technology to research");
-        setShowOnboardingType("research");
+        setShowOnboardingType({ type: "research" });
         return;
       }
     } else {
@@ -186,8 +187,8 @@ const EndTurnButton: React.FC<EndTurnButtonProps> = ({ setShowOnboardingType, op
       const computeBudgetInstruction = anchor.web3.ComputeBudgetProgram.setComputeUnitLimit({
           units: 1000000,
       });
-      const addPriorityFee = anchor.web3.ComputeBudgetProgram.setComputeUnitPrice({ 
-        microLamports: 1 
+      const addPriorityFee = anchor.web3.ComputeBudgetProgram.setComputeUnitPrice({
+        microLamports: 1
       });
       const transaction = new anchor.web3.Transaction();
       transaction.add(computeBudgetInstruction);

--- a/src/components/GameMap.tsx
+++ b/src/components/GameMap.tsx
@@ -591,6 +591,7 @@ const GameMap: React.FC<GameMapProps> = ({ debug, logMessage }) => {
           return (
             <div
               key={index}
+              id={`tile-${col}-${row}`}
               className={`game-tile ${isInRangeForAnyUnit ? "in-range" : ""}`}
               onClick={() => handleTileClick(col, row, currentUnits)}
             >

--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -55,7 +55,7 @@ const researchSteps = [
 
 const productionSteps = [
   {
-    target: ".terrain.village",
+    target: "#tile-{col}-{row}",
     content: <div>Click on the city and add unit or building to the production queue.</div>,
   },
 ];
@@ -78,13 +78,17 @@ const TopMenu: React.FC<TopMenuProps> = ({ debug, setDebug }) => {
   const { toggleBackgroundMusic } = useSound();
   const [isModalOpen, setModalOpen] = useState(false);
   const [modalContent, setModalContent] = useState("");
-  
+
 
   // const [isModalOpen, setModalOpen] = useState(true);
   // const [modalContent, setModalContent] = useState("New Research");
   const [openDialog, setOpenDialog] = useState(false);
-  const [showOnboardingType, setShowOnboardingType] = useState<"production" | "research" | null>(null);
+  const [showOnboardingType, setShowOnboardingType] = useState<{ type: "production" | "research", col?: number, row?: number } | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
+
+  console.log({
+    showOnboardingType
+  })
 
   let totalFoodYield = 0;
   let totalScienceYield = 0;
@@ -406,7 +410,15 @@ const TopMenu: React.FC<TopMenuProps> = ({ debug, setDebug }) => {
       </div>
       <Joyride
         run={showOnboardingType}
-        steps={showOnboardingType === "production" ? productionSteps : researchSteps}
+        steps={showOnboardingType?.type === "production" ? productionSteps.map((step) => {
+          let target = step.target.replace('{col}', String(showOnboardingType?.col));
+          target = target.replace('{row}', String(showOnboardingType?.row));
+
+          return {
+            ...step,
+            target
+          }
+        }) : researchSteps}
         styles={{
           options: {
             backgroundColor: "rgb(34, 47, 59)",


### PR DESCRIPTION
> It is not a final solution

The [issue #7](https://github.com/proxycapital/solana-civ-frontend/issues/7) has one more problem: the icon appears in the NPC village. The CSS selector only targets a terrain that is a village. In some cases (in my tests, always), the selector catches the NPC village.

Evidence


https://github.com/proxycapital/solana-civ-frontend/assets/15316761/ad041503-01fb-41fe-b63f-fb104603d75a

The simplest solution is not just to set a state as 'production', but to create an interface for this state that includes a type, and the column and row that point to the city tile. This is the result:

https://github.com/proxycapital/solana-civ-frontend/assets/15316761/80f47d98-dbbc-42ac-afcb-6a67183d55f3
